### PR TITLE
adiciona APIs POST /regions/setup e POST /regions/rpi

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,7 @@
       "typescript"
     ],
     "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true
+      "source.fixAll.eslint": "explicit"
     },
     "workbench.colorCustomizations": {
       "activityBar.activeBorder": "#ffbfc9"

--- a/PROXIMOS-PASSOS.md
+++ b/PROXIMOS-PASSOS.md
@@ -5,11 +5,14 @@
 Dois endpoints foram adicionados ao Boot-Back para incorporar os comandos `pxetools` que antes precisavam ser executados manualmente (conforme mencionado no README).
 
 ### `POST /regions/setup`
+
 Executa em sequência:
+
 1. `rpi/pxetools-install.sh` — instala os serviços no servidor de boot
 2. `rpi/pxetools-setup.sh` — faz a configuração inicial
 
 Retorna:
+
 ```json
 {
   "install": "<output do script de instalação>",
@@ -18,25 +21,29 @@ Retorna:
 ```
 
 ### `POST /regions/rpi`
+
 Executa `sudo pxetools --add <serial>` com o número de série recebido no body.
 
 Body esperado:
+
 ```json
-{ "serial": "9f55bbfd" }
+{"serial": "9f55bbfd"}
 ```
 
 Retorna:
+
 ```json
-{ "output": "<output do pxetools>" }
+{"output": "<output do pxetools>"}
 ```
 
 ---
 
 ## Frontend (site de configuração)
 
-Um site simples foi criado em paralelo no projeto [`iot-tofu-site`](https://github.com/paulovcmonteiro/iot-tofu-site) *(repositório separado)* usando Next.js + Tailwind, hospedável na Vercel.
+Um site simples foi criado em paralelo no projeto [`iot-tofu-site`](https://github.com/paulovcmonteiro/iot-tofu-site) _(repositório separado)_ usando Next.js + Tailwind, hospedável na Vercel.
 
 O site permite que o usuário final:
+
 1. Clique em **Inicializar Region** → chama `POST /regions/setup`
 2. Digite o número de série e clique em **Adicionar RPi** → chama `POST /regions/rpi`
 
@@ -47,28 +54,36 @@ A URL da API é configurada via variável de ambiente `NEXT_PUBLIC_API_URL`.
 ## Próximos passos sugeridos
 
 ### 1. Validar os scripts no hardware real
+
 Os endpoints executam os scripts shell diretamente. Antes de usar em produção, testar no Tofu com:
+
 ```bash
 curl -X POST http://localhost:3000/regions/setup
 curl -X POST http://localhost:3000/regions/rpi -H "Content-Type: application/json" -d '{"serial":"9f55bbfd"}'
 ```
 
 ### 2. Tratar erros dos scripts
+
 Atualmente, se um script falhar (exit code != 0), o Node.js lança uma exceção não tratada. Sugestão: capturar o erro e retornar HTTP 500 com a mensagem de erro do shell.
 
 ### 3. Adicionar as demais APIs de pxetools
+
 Seguindo o mesmo padrão, as próximas APIs naturais seriam:
+
 - `GET /regions/rpi` → `sudo pxetools --list`
 - `DELETE /regions/rpi/:serial` → `sudo pxetools --remove <serial>`
 - `POST /regions/reset` → `rpi/pxetools-reset.sh`
 
 ### 4. Deploy do frontend
+
 - Criar repositório para o `iot-tofu-site`
 - Conectar na Vercel
 - Setar `NEXT_PUBLIC_API_URL` com o endereço público do Boot-Back
 
 ### 5. CORS
+
 Quando o frontend estiver num domínio público chamando a API, será necessário habilitar CORS no Boot-Back. No LoopBack4, isso é feito em `src/application.ts`:
+
 ```typescript
 this.api({
   openapi: '3.0.0',
@@ -76,4 +91,66 @@ this.api({
 });
 // adicionar middleware de CORS
 ```
+
 Ou via pacote `@loopback/rest` com a opção `cors` na configuração do RestApplication.
+
+### 6.1 Habilitar CORS em uma API do IBM Loopback
+
+Habilitar o CORS (Compartilhamento de Recursos entre Origens) no LoopBack 4 (a versão atual e mais comum usada em ambientes IBM Cloud/Code Engine) é feito configurando o servidor REST na inicialização da aplicação, pois o CORS já está integrado.Aqui estão as formas de habilitar:1. Habilitar CORS com configurações padrão (Recomendado)Para permitir que qualquer domínio acesse sua API com as configurações de segurança padrão, edite o arquivo src/application.ts ou onde o RestApplication é iniciado.
+
+```typescript
+// src/application.ts
+
+import {BootMixin} from '@loopback/boot';
+import {ApplicationConfig} from '@loopback/core';
+import {RepositoryMixin} from '@loopback/repository';
+import {RestApplication} from '@loopback/rest';
+
+export class MyApplication extends BootMixin(RepositoryMixin(RestApplication)) {
+  constructor(options: ApplicationConfig = {}) {
+    super(options);
+
+    // Habilitar CORS com configurações padrão
+    this.restServer.configureCors({
+      origin: '*', // Permite todas as origens (ajuste para produção)
+      methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+      credentials: true,
+    });
+  }
+}
+```
+
+### 6.2. Habilitar via index.ts (Configuração Customizada)
+
+Alternativamente, você pode definir as configurações de CORS na função main no arquivo src/index.ts:
+
+```typescript
+// src/index.ts
+
+export async function main(options: ApplicationConfig = {}) {
+  const config = {
+    rest: {
+      port: +(process.env.PORT ?? 3000),
+      host: process.env.HOST ?? 'localhost',
+      // Configuração de CORS
+      cors: {
+        origin: 'http://meu-frontend.com', // Origem específica
+        methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+        preflightContinue: false,
+        optionsSuccessStatus: 204,
+        credentials: true,
+      },
+    },
+  };
+  const app = new MyApplication(config);
+  // ... resto do código
+}
+```
+
+### 6.3. Habilitar CORS em Ambientes IBM Cloud (Code Engine/API Connect)
+
+Se sua aplicação está rodando em contêineres, certifique-se de que o CORS está habilitado no código Node.js/Express, conforme mostrado acima, pois o IBM Code Engine é baseado em Express.Se estiver usando o IBM API Connect, você pode ativar o CORS diretamente na guia Gateway da definição da API, selecionando Ativar CORS.
+
+### 6.4 Como verificar se funcionou
+
+Após reiniciar a API, o navegador deve receber o cabeçalho Access-Control-Allow-Origin: \* (ou o domínio que você definiu) nas respostas.

--- a/PROXIMOS-PASSOS.md
+++ b/PROXIMOS-PASSOS.md
@@ -1,0 +1,79 @@
+# Próximos Passos — APIs de Region e Frontend
+
+## O que foi feito neste PR
+
+Dois endpoints foram adicionados ao Boot-Back para incorporar os comandos `pxetools` que antes precisavam ser executados manualmente (conforme mencionado no README).
+
+### `POST /regions/setup`
+Executa em sequência:
+1. `rpi/pxetools-install.sh` — instala os serviços no servidor de boot
+2. `rpi/pxetools-setup.sh` — faz a configuração inicial
+
+Retorna:
+```json
+{
+  "install": "<output do script de instalação>",
+  "setup": "<output do script de setup>"
+}
+```
+
+### `POST /regions/rpi`
+Executa `sudo pxetools --add <serial>` com o número de série recebido no body.
+
+Body esperado:
+```json
+{ "serial": "9f55bbfd" }
+```
+
+Retorna:
+```json
+{ "output": "<output do pxetools>" }
+```
+
+---
+
+## Frontend (site de configuração)
+
+Um site simples foi criado em paralelo no projeto [`iot-tofu-site`](https://github.com/paulovcmonteiro/iot-tofu-site) *(repositório separado)* usando Next.js + Tailwind, hospedável na Vercel.
+
+O site permite que o usuário final:
+1. Clique em **Inicializar Region** → chama `POST /regions/setup`
+2. Digite o número de série e clique em **Adicionar RPi** → chama `POST /regions/rpi`
+
+A URL da API é configurada via variável de ambiente `NEXT_PUBLIC_API_URL`.
+
+---
+
+## Próximos passos sugeridos
+
+### 1. Validar os scripts no hardware real
+Os endpoints executam os scripts shell diretamente. Antes de usar em produção, testar no Tofu com:
+```bash
+curl -X POST http://localhost:3000/regions/setup
+curl -X POST http://localhost:3000/regions/rpi -H "Content-Type: application/json" -d '{"serial":"9f55bbfd"}'
+```
+
+### 2. Tratar erros dos scripts
+Atualmente, se um script falhar (exit code != 0), o Node.js lança uma exceção não tratada. Sugestão: capturar o erro e retornar HTTP 500 com a mensagem de erro do shell.
+
+### 3. Adicionar as demais APIs de pxetools
+Seguindo o mesmo padrão, as próximas APIs naturais seriam:
+- `GET /regions/rpi` → `sudo pxetools --list`
+- `DELETE /regions/rpi/:serial` → `sudo pxetools --remove <serial>`
+- `POST /regions/reset` → `rpi/pxetools-reset.sh`
+
+### 4. Deploy do frontend
+- Criar repositório para o `iot-tofu-site`
+- Conectar na Vercel
+- Setar `NEXT_PUBLIC_API_URL` com o endereço público do Boot-Back
+
+### 5. CORS
+Quando o frontend estiver num domínio público chamando a API, será necessário habilitar CORS no Boot-Back. No LoopBack4, isso é feito em `src/application.ts`:
+```typescript
+this.api({
+  openapi: '3.0.0',
+  // ...
+});
+// adicionar middleware de CORS
+```
+Ou via pacote `@loopback/rest` com a opção `cors` na configuração do RestApplication.

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,2 +1,3 @@
 export * from './category.controller';
 export * from './ping.controller';
+export * from './region.controller';

--- a/src/controllers/region.controller.ts
+++ b/src/controllers/region.controller.ts
@@ -1,0 +1,79 @@
+import {post, requestBody, response} from '@loopback/rest';
+import {exec} from 'child_process';
+import * as path from 'path';
+import {promisify} from 'util';
+
+const execAsync = promisify(exec);
+
+const RPI_DIR = path.resolve(__dirname, '../../rpi');
+
+export class RegionController {
+  @post('/regions/setup')
+  @response(200, {
+    description: 'Install and setup pxetools on the boot server',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          properties: {
+            install: {type: 'string'},
+            setup: {type: 'string'},
+          },
+        },
+      },
+    },
+  })
+  async setup(): Promise<object> {
+    const installScript = path.join(RPI_DIR, 'pxetools-install.sh');
+    const setupScript = path.join(RPI_DIR, 'pxetools-setup.sh');
+
+    const {stdout: installOut, stderr: installErr} = await execAsync(
+      `bash ${installScript}`,
+    );
+    const {stdout: setupOut, stderr: setupErr} = await execAsync(
+      `bash ${setupScript}`,
+    );
+
+    return {
+      install: installOut || installErr,
+      setup: setupOut || setupErr,
+    };
+  }
+
+  @post('/regions/rpi')
+  @response(200, {
+    description: 'Add a RPi to the region by serial number',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          properties: {
+            output: {type: 'string'},
+          },
+        },
+      },
+    },
+  })
+  async addRpi(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['serial'],
+            properties: {
+              serial: {type: 'string', example: '9f55bbfd'},
+            },
+          },
+        },
+      },
+    })
+    body: {serial: string},
+  ): Promise<object> {
+    const {serial} = body;
+    const {stdout, stderr} = await execAsync(
+      `sudo pxetools --add ${serial}`,
+    );
+    return {output: stdout || stderr};
+  }
+}


### PR DESCRIPTION
## Summary

- `POST /regions/setup`: executa `pxetools-install.sh` e `pxetools-setup.sh` no servidor de boot
- `POST /regions/rpi`: executa `sudo pxetools --add <serial>` para adicionar um RPi à região pelo número de série

Incorpora ao Boot-Back os comandos pxetools que antes precisavam ser executados manualmente, conforme mencionado no README.

## Test plan

- [ ] `POST /regions/setup` retorna output dos dois scripts sem erro
- [ ] `POST /regions/rpi` com body `{"serial": "9f55bbfd"}` retorna output do pxetools
- [ ] Checar no swagger UI (LB4) se os endpoints aparecem corretamente documentados

🤖 Generated with [Claude Code](https://claude.com/claude-code)